### PR TITLE
Use the en_GB dictionary, not en_UK.

### DIFF
--- a/teletext/t42/packet.py
+++ b/teletext/t42/packet.py
@@ -150,7 +150,7 @@ class BroadcastPacket(Packet):
 from printer import PrinterANSI
 
 import enchant
-d = enchant.Dict('en_UK')
+d = enchant.Dict('en_GB')
 
 
 freecombos = [


### PR DESCRIPTION
en_UK would be English as spoken in Ukraine; since that dictionary
doesn't exist, Enchant's aspell backend selects an American English
dictionary instead, which doesn't include useful words like
"programmes".