### PR TITLE
Windows

### DIFF
--- a/t42html
+++ b/t42html
@@ -11,7 +11,7 @@ def sciter(packet_iter):
         spellcheck(packet)
         yield packet
 
-service = make_service(sciter(reader(open(sys.argv[1]))))
+service = make_service(sciter(reader(open(sys.argv[1], 'rb'))))
 
 pages_set = service.pages_set()
 

--- a/t42pipe
+++ b/t42pipe
@@ -18,6 +18,10 @@ import errno
 from teletext.t42.pipeline import reader, demux, paginate, subpage_squash, row_squash, make_service
 from teletext.misc.all import All
 
+if sys.platform == "win32":
+    import os, msvcrt
+    msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+
 parser = argparse.ArgumentParser(description='Process some integers.')
 parser.add_argument('inputfile', type=str, help='Read VBI samples from this file.')
 group = parser.add_mutually_exclusive_group()

--- a/teletext/t42/elements.py
+++ b/teletext/t42/elements.py
@@ -48,8 +48,8 @@ class PageHeader(object):
             errors += e
             values.append(v)
 
-        subpage = (values[0] & 0x7f) | ((values[1] & 0x3f) <<8)
-        control = (values[0] >> 7) | (values[1] >> 5) | (values[2] << 3)
+        subpage = (values[0] & 0x7f) | ((values[1] & 0x3f) << 8)
+        control = (values[0] >> 7) | ((values[1] >> 5) & 0x6) | (values[2] << 3)
         return cls(page, subpage, control, errors)
 
     def to_bytes(self):
@@ -86,8 +86,8 @@ class PageLink(object):
             errors += e
             values.append(v)
 
-        subpage = (values[0] & 0x7f) | ((values[1] & 0x3f) <<8)
-        magazine = (values[0] >> 7) | ((values[1] >> 6)<<1)
+        subpage = (values[0] & 0x7f) | ((values[1] & 0x3f) << 8)
+        magazine = (values[0] >> 7) | ((values[1] >> 5) & 0x6)
         return cls(magazine^current_magazine, page, subpage, errors)
 
     def __str__(self):

--- a/teletext/t42/packet.py
+++ b/teletext/t42/packet.py
@@ -1,4 +1,5 @@
 import numpy
+import sys
 
 from coding import *
 from descriptors import *
@@ -146,56 +147,56 @@ class BroadcastPacket(Packet):
     def to_bytes(self):
         return self.mrag.to_bytes() + '                    ' + parity_encode(self.displayable).tostring()
 
+try:
+    import enchant
+    d = enchant.Dict('en_GB')
 
-from printer import PrinterANSI
-
-import enchant
-d = enchant.Dict('en_GB')
-
-
-freecombos = [
-    set(['e', 'i', 'j']),
-    set(['r', 's', 't', 'u', 'k']),
-    set(['y', 'z']),
-    set(['k', 'g', 'o']),
-    set(['n', 'm']),
-    set(['d', 'h']),
-]
+    freecombos = [
+        set(['e', 'i', 'j']),
+        set(['r', 's', 't', 'u', 'k']),
+        set(['y', 'z']),
+        set(['k', 'g', 'o']),
+        set(['n', 'm']),
+        set(['d', 'h']),
+    ]
 
 
-def check_pair(x, y):
-    x = x.lower()
-    y = y.lower()
-    if x == y:
-        return 0
-    for s in freecombos:
-        if x in s and y in s:
+    def check_pair(x, y):
+        x = x.lower()
+        y = y.lower()
+        if x == y:
             return 0
-    return 1
+        for s in freecombos:
+            if x in s and y in s:
+                return 0
+        return 1
 
 
-def weighted_hamming(a, b):
-    count = 0
-    return sum([check_pair(x, y) for x,y in zip(a, b)])
+    def weighted_hamming(a, b):
+        count = 0
+        return sum([check_pair(x, y) for x,y in zip(a, b)])
 
 
-def case_match(word, src):
-    return ''.join([c.lower() if d.islower() else c.upper() for c, d in zip(word, src)])
+    def case_match(word, src):
+        return ''.join([c.lower() if d.islower() else c.upper() for c, d in zip(word, src)])
 
-def spellcheck(packet):
-    if type(packet) == DisplayPacket or type(packet) == HeaderPacket:
-        words = str(PrinterANSI(packet.displayable, False)).decode('utf-8')
-        words = ''.join([c if c.isalnum() else ' ' for c in words])
-        words = words.split(' ')
+    def spellcheck(packet):
+        if type(packet) == DisplayPacket or type(packet) == HeaderPacket:
+            words = str(PrinterANSI(packet.displayable, False)).decode('utf-8')
+            words = ''.join([c if c.isalnum() else ' ' for c in words])
+            words = words.split(' ')
 
-        for n,w in enumerate(words):
-          if len(w) > 2 and not d.check(w.lower()):
-            s = filter(lambda x: len(x) == len(w) and weighted_hamming(x, w) == 0, d.suggest(w.lower()))
-            if len(s) > 0:
-                words[n] = case_match(s[0], w)
+            for n,w in enumerate(words):
+              if len(w) > 2 and not d.check(w.lower()):
+                s = filter(lambda x: len(x) == len(w) and weighted_hamming(x, w) == 0, d.suggest(w.lower()))
+                if len(s) > 0:
+                    words[n] = case_match(s[0], w)
 
-        words = ' '.join(words)
-        for n,c in enumerate(words):
-            if c != ' ':
-                packet.displayable[n] = ord(c)
-
+            words = ' '.join(words)
+            for n,c in enumerate(words):
+                if c != ' ':
+                    packet.displayable[n] = ord(c)
+except ImportError:
+    sys.stderr.write('enchant package unavailable\n')
+    def spellcheck(packet):
+        pass #do nothing

--- a/teletext/vbi/training.py
+++ b/teletext/vbi/training.py
@@ -28,7 +28,7 @@ def de_bruijn(k, n):
 
 
 def load_pattern():
-    data = open(os.path.join(os.path.dirname(__file__),'data','debruijn.dat')).read()
+    data = open(os.path.join(os.path.dirname(__file__),'data','debruijn.dat'), 'rb').read()
     pattern = numpy.fromstring(data+data[:pattern_length], dtype=numpy.uint8)
     return pattern
 


### PR DESCRIPTION
Mostly reading files in binary mode to avoid unhelpful line ending translation and setting stdout to binary where required for the same reason.
I was having great difficulty getting enchant to work on Windows with on my python setup, so allow everything else to work if it's not present.