### PR TITLE
Refactor multiprocessing to use zeromq

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
         ]
     },
     install_requires=[
-        'numpy', 'scipy', 'click', 'tqdm',
-        'windows-curses;platform_system=="Windows"'
+        'numpy', 'scipy', 'click', 'tqdm',  'pyzmq',
+        'windows-curses;platform_system=="Windows"',
     ],
     extras_require={
         'spellcheck': ['pyenchant'],

--- a/teletext/mp.py
+++ b/teletext/mp.py
@@ -160,7 +160,7 @@ class _PureGeneratorPoolMP(object):
                     yield from received[received_count]
                     del received[received_count]
                     received_count += 1
-                    if sent_count - received_count < self._processes * 3:
+                    if not done and sent_count - received_count < self._processes * 3:
                         poller.register(self._work, zmq.POLLOUT)
 
                 if done and sent_count == received_count:

--- a/teletext/mp.py
+++ b/teletext/mp.py
@@ -130,9 +130,9 @@ class _PureGeneratorPoolMP(object):
 
     def apply(self, iterable):
         try:
-            chunksize = min(128, 1+(len(iterable)//len(self._procs)))
+            chunksize = min(64, 1+(len(iterable)//len(self._procs)))
         except TypeError:
-            chunksize = 128
+            chunksize = 64
 
         it = iter(iterable)
         iterable = enumerate(iter(lambda: list(itertools.islice(it, chunksize)), []))
@@ -160,7 +160,7 @@ class _PureGeneratorPoolMP(object):
                     yield from received[received_count]
                     del received[received_count]
                     received_count += 1
-                    if sent_count - received_count < self._processes * 6:
+                    if sent_count - received_count < self._processes * 3:
                         poller.register(self._work, zmq.POLLOUT)
 
                 if done and sent_count == received_count:
@@ -170,7 +170,7 @@ class _PureGeneratorPoolMP(object):
                 try:
                     self._work.send_pyobj(next(iterable))
                     sent_count += 1
-                    if sent_count - received_count > self._processes * 10:
+                    if sent_count - received_count > self._processes * 4:
                         poller.unregister(self._work)
                 except StopIteration:
                     done = True

--- a/teletext/tests/test_mp.py
+++ b/teletext/tests/test_mp.py
@@ -125,17 +125,20 @@ class TestMPMultiSigInt(unittest.TestCase):
     def items(self):
         with PureGeneratorPool(multiply, self.pool_size, 1) as pool:
             self.pool = pool
-            yield from pool.apply(islice(count(), 100))
+            yield from pool.apply(islice(count(), 2000))
 
     def test_sigint_to_self(self):
         result = self.items()
+        next(result)
         with self.assertRaises(KeyboardInterrupt):
-            for r in result:
-                ctrl_c(os.getpid())
+            ctrl_c(os.getpid())
 
     @unittest.skipIf(sys.platform.startswith('win'), "Can't send ctrl-c to an individual process on Windows")
     def test_sigint_to_child(self):
         result = self.items()
+        next(result)
         with self.assertRaises(ChildProcessError):
+            for i in range(self.pool_size):
+                ctrl_c(self.pool._procs[i].pid)
             for r in result:
-                ctrl_c(self.pool._procs[r%self.pool_size].pid)
+                pass


### PR DESCRIPTION
The old multiprocessing implementation used OS pipes directly. This worked okay on Linux but was extremely problematic on Windows, leading to deadlocks. There were also problems with clean-up at exit.

Zeromq uses TCP sockets instead. It is a bit slower due to increased overhead, but is much more portable and does not seem to deadlock.

This adds a new dependency on zeromq, but that is easily installed with pip. No external native libraries are required as far as I know.