### PR TITLE
opencl implementation

### DIFF
--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -61,8 +61,8 @@ Then it is divided into "bytes". Each one is compared against the training
 tables, including a few bits before and after. The closest match is the most
 likely original signal.
 
-This algorithm can be performed in parallel using CUDA. This allows deconvolution
-to run in near realtime with a GTX 780.
+This algorithm can be performed in parallel using CUDA or OpenCL. This allows
+deconvolution to run in near realtime with a GTX 780.
 
 See TRAINING.md for more.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ To install with optional dependencies run:
 If CUDA or pyenchant are not available for your platform simply omit them
 from the install command.
 
+In order to use OpenCL you need to install pyopencl and the appropriate
+opencl runtime for your card.  Then run the deconvolve command with the '-O'
+option.
+
 In order for the output to be rendered correctly you need to use a specific
 font and terminal:
 

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -41,8 +41,28 @@ class PatternOpenCL(Pattern):
 
         self.queue = cl.CommandQueue(openclctx)
 
-        raise Exception("Not yet implemented")
+        mf = cl.mem_flags
+        # patterns is already float32 (see Pattern __init__)
+        self.patterns_gpu = cl.Buffer(openclctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=self.patterns)
+
+        # the input of the correlate -
+        # size copying CUDA code, something like 40chars, 8 bits each, float??
+        self.input_match = cl.Buffer(openclctx, mf.READ_WRITE, 4*((40*8)+16))
+
+        # output of the correlate
+        self.result_match = cl.Buffer(openclctx, mf.READ_WRITE, 4*40*self.n)
 
     def match(self, inp):
-        raise Exception("Not yet implemented")
+        l = (len(inp)//8)-2
+        x = l & -l # highest power of two which divides l, up to 8
+        y = min(1024//x, self.n)
+
+        # copy data in
+        cl.enqueue_copy(self.queue, self.input_match, inp.astype(np.float32))
+        # call corellate
+        self.prg.correlate(self.queue, (l, self.n), None,
+                           self.input_match, self.patterns_gpu, self.result_match,
+                           np.int32(self.start), np.int32(self.end))
+        # TODO do a min pass to find smallest (start with numpy?)
+        #raise Exception("Not yet implemented (match)")
 

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -1,0 +1,48 @@
+# * Copyright 2023 Dr. David Alan Gilbert <dave@treblig.org>
+# *   based on Alistair's patterncuda.py
+# *
+# * License: This program is free software; you can redistribute it and/or
+# * modify it under the terms of the GNU General Public License as published
+# * by the Free Software Foundation; either version 3 of the License, or (at
+# * your option) any later version. This program is distributed in the hope
+# * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# * GNU General Public License for more details.
+
+import numpy as np
+import pyopencl as cl
+
+from .pattern import Pattern
+
+openclctx = cl.create_some_context(interactive=False)
+
+class PatternOpenCL(Pattern):
+    prg = cl.Program(openclctx, """
+    __kernel void correlate(global float* input, global float* patterns, global float* result,
+                            int range_low, int range_high)
+    {
+      int x = get_global_id(0);
+      int y = get_global_id(1);
+      int iidx = x * 8;
+      int ridx = (x * get_global_size(1)) + y;
+      int pidx = y * 24;
+
+      result[ridx] = 0;
+
+      for (int i=range_low;i<range_high;i++) {
+        float d = input[iidx+i] - patterns[pidx+i];
+        result[ridx] += (d*d);
+      }
+    }
+    """).build()
+
+    def __init__(self, filename):
+        Pattern.__init__(self, filename)
+
+        self.queue = cl.CommandQueue(openclctx)
+
+        raise Exception("Not yet implemented")
+
+    def match(self, inp):
+        raise Exception("Not yet implemented")
+

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -73,7 +73,7 @@ class PatternOpenCL(Pattern):
         self.input_match = cl.Buffer(openclctx, mf.READ_WRITE, 4*((40*8)+16))
 
         # output of the correlate
-        self.result_match = cl.Buffer(openclctx, mf.READ_WRITE, 4*40*self.n)
+        self.result_match = cl.Buffer(openclctx, mf.HOST_NO_ACCESS, 4*40*self.n)
 
         # output of the min pass - an integer index to which pattern was best
         # for each character

--- a/tests/vbi/test_patternopencl.py
+++ b/tests/vbi/test_patternopencl.py
@@ -1,0 +1,29 @@
+import pathlib
+import unittest
+
+import numpy as np
+
+from teletext.vbi.pattern import Pattern
+try:
+    from teletext.vbi.patternopencl import PatternOpenCL
+
+
+    class PatternOpenCLTestCase(unittest.TestCase):
+
+        def setUp(self):
+            p = pathlib.Path(__file__).parent.parent.parent / 'teletext' / 'vbi' / 'data' / 'vhs' / 'parity.dat'
+            self.pattern = Pattern(p)
+            self.patternopencl = PatternOpenCL(p)
+
+        def test_equal_to_cpu(self):
+            arr = np.arange(256, dtype=np.uint8)
+            a = self.pattern.match(arr)
+            b = self.patternopencl.match(arr)
+
+            #self.assertTrue(all(a==b), 'CPU and OpenCL pattern matching produced different results.')
+            self.assertEqual(a.tolist(), b.tolist(), 'CPU and OpenCL pattern matching produced different results.')
+
+except ModuleNotFoundError as e:
+    if e.name != 'pyopencl':
+        raise
+


### PR DESCRIPTION
This set implements the correlate and min steps in OpenCL;    it's enabled by passing the -O option to deconvolve.
It's actually currently running slower than my CPU for me; but I'm on a high end CPU (Ryzen 3950X) and low end (Radeon RX550 ) GPU; so I'd be interested to see what other people get.  I'm seeing about 260 LPS on the GPU and 350 on the CPU; although the machine feels like a swamp and runs hot as hell when run on the CPU and is quite usable when using the GPU.

On Fedora 37 I'm seeing a compiler warning during startup:

warning: argument unused during compilation: '-I /usr/lib64/python3.11/site-packages/pyopencl/cl' [-Wunused-command-line-argument]

that looks like a distro bug - that's just because I'm not using any includes as far as I can tell.
