### PR TITLE
list: Optionally display a count

### DIFF
--- a/teletext/cli/teletext.py
+++ b/teletext/cli/teletext.py
@@ -137,14 +137,17 @@ def _list(packets, subpages):
 
     packets = (p for p in packets if not p.is_padding())
 
-    seen = set()
+    seen = {}
     try:
         for pl in pipeline.paginate(packets):
             s = Subpage.from_packets(pl)
             identifier = f'{s.mrag.magazine}{s.header.page:02x}'
             if subpages:
                 identifier += f':{s.header.subpage:04x}'
-            seen.add(identifier)
+            if identifier in seen:
+                seen[identifier]+=1
+            else:
+                seen[identifier]=1
     except KeyboardInterrupt:
         print('\n')
     finally:

--- a/teletext/cli/teletext.py
+++ b/teletext/cli/teletext.py
@@ -125,11 +125,12 @@ def grep(packets, pages, subpages, paginate, regex, v, i, n, keep_empty):
 
 
 @teletext.command(name='list')
+@click.option('-c', '--count', is_flag=True, help='Show counts of each entry.')
 @click.option('-s', '--subpages', is_flag=True, help='Also list subpages.')
 @paginated(always=True, filtered=False)
 @packetreader()
 @progressparams(progress=True, mag_hist=True)
-def _list(packets, subpages):
+def _list(packets, count, subpages):
 
     """List pages present in a t42 stream."""
 
@@ -151,6 +152,12 @@ def _list(packets, subpages):
     except KeyboardInterrupt:
         print('\n')
     finally:
+        if count:
+            maxdigits = len(str(max(seen.values())))
+            formatstr="{page}/{count:0" + str(maxdigits) +"}"
+        else:
+            formatstr="{page}"
+        seen = list(map(lambda e: formatstr.format(page = e[0], count = e[1]), seen.items()))
         print('\n'.join(textwrap.wrap(' '.join(sorted(seen)))))
 
 


### PR DESCRIPTION
    list: Optionally display a count
    
    Add a -c flag to display the count of each page shown in the list.
    I find it interesting when looking for potentially interesting page
    numbers, while weeding out ones that are only there due to errors,
    e.g.:
    
    633/000112 634/000115 635/000109 636/000119 637/000115 638/000122
    63d/000001 63f/000002 64c/000001 64f/000001 661/000002 667/000121
    
    those 63d/63f/64c/64f aren't fun hidden hex pages, they're just
    corruptions that are much lower frequency than the rest of the 6xx
    magazine.
    
    The opposite tends to happen for ff's (which things tend to corrupt
    towards); e.g.:
    695/000121 696/000121 697/000114 698/000109 699/000119 6a2/000001
    6b0/000001 6b1/000002 6ba/000001 6c1/000002 6ca/000002 6ff/032316
    
    That 6ff just has a pile of random corrupted pages landing in it.
