### PR TITLE
VBI/opencl: Add a missing wait

### DIFF
--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -169,7 +169,7 @@ class PatternOpenCL(Pattern):
 
 
         # and get the index values back from OpenCL
-        cl.enqueue_copy(self.queue, self.result_minidx_np, self.result_minidx, wait_for = (e_min2,))
-
+        e_out = cl.enqueue_copy(self.queue, self.result_minidx_np, self.result_minidx, wait_for = (e_min2,))
+        e_out.wait()
         return self.bytes[self.result_minidx_np[:l],0]
 


### PR DESCRIPTION
Add a missing wait() at the end of the queued chain. Not sure if this has actually caused any corrupt data but I guess it's possible.
Foudn when trying to turn profiling on, only broke with the Mesa set, not the ROCm set for some reason - but I think Mesa is right.