### PR TITLE
fix, Profile, Vectorise, tune

### DIFF
--- a/teletext/cli/teletext.py
+++ b/teletext/cli/teletext.py
@@ -137,14 +137,17 @@ def _list(packets, subpages):
 
     packets = (p for p in packets if not p.is_padding())
 
-    seen = set()
+    seen = {}
     try:
         for pl in pipeline.paginate(packets):
             s = Subpage.from_packets(pl)
             identifier = f'{s.mrag.magazine}{s.header.page:02x}'
             if subpages:
                 identifier += f':{s.header.subpage:04x}'
-            seen.add(identifier)
+            if identifier in seen:
+                seen[identifier]+=1
+            else:
+                seen[identifier]=1
     except KeyboardInterrupt:
         print('\n')
     finally:

--- a/teletext/cli/teletext.py
+++ b/teletext/cli/teletext.py
@@ -125,11 +125,12 @@ def grep(packets, pages, subpages, paginate, regex, v, i, n, keep_empty):
 
 
 @teletext.command(name='list')
+@click.option('-c', '--count', is_flag=True, help='Show counts of each entry.')
 @click.option('-s', '--subpages', is_flag=True, help='Also list subpages.')
 @paginated(always=True, filtered=False)
 @packetreader()
 @progressparams(progress=True, mag_hist=True)
-def _list(packets, subpages):
+def _list(packets, count, subpages):
 
     """List pages present in a t42 stream."""
 
@@ -151,6 +152,12 @@ def _list(packets, subpages):
     except KeyboardInterrupt:
         print('\n')
     finally:
+        if count:
+            maxdigits = len(str(max(seen.values())))
+            formatstr="{page}/{count:0" + str(maxdigits) +"}"
+        else:
+            formatstr="{page}"
+        seen = list(map(lambda e: formatstr.format(page = e[0], count = e[1]), seen.items()))
         print('\n'.join(textwrap.wrap(' '.join(sorted(seen)))))
 
 

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -172,7 +172,7 @@ class PatternOpenCL(Pattern):
 
 
         # and get the index values back from OpenCL
-        cl.enqueue_copy(self.queue, self.result_minidx_np, self.result_minidx, wait_for = (e_min2,))
-
+        e_out = cl.enqueue_copy(self.queue, self.result_minidx_np, self.result_minidx, wait_for = (e_min2,))
+        e_out.wait()
         return self.bytes[self.result_minidx_np[:l],0]
 

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -29,9 +29,12 @@ class PatternOpenCL(Pattern):
       float d;
 
       result[ridx] = 0;
+      input+=iidx+range_low;
+      patterns+=pidx+range_low;
+      range_high-=range_low;
 
-      for (int i=range_low;i<range_high;i++) {
-        d = input[iidx+i] - patterns[pidx+i];
+      for (int i=0;i<range_high;i++) {
+        d = input[i] - patterns[i];
         result[ridx] += (d*d);
       }
     }

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -28,15 +28,23 @@ class PatternOpenCL(Pattern):
       int pidx = y * 24;
       float d;
 
-      result[ridx] = 0;
       input+=iidx+range_low;
       patterns+=pidx+range_low;
       range_high-=range_low;
 
-      for (int i=0;i<range_high;i++) {
-        d = input[i] - patterns[i];
-        result[ridx] += (d*d);
+      int i=0;
+      float res = 0;
+      float4 vd;
+      for (;(i+3)<range_high;i+=4) {
+        vd = vload4(0, input+i) - vload4(0, patterns+i);
+        res += dot(vd, vd);
       }
+
+      for (;i<range_high;i++) {
+        d = input[i] - patterns[i];
+        res += (d*d);
+      }
+      result[ridx] = res;
     }
 
     // Each workitem takes one character x npatterns/minpar values

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -97,14 +97,31 @@ class PatternOpenCL(Pattern):
       float bestval = tmp_val[iidx];
       float val;
 
-      iidx+=width;
-      for (int i=1;i<minpar;i++,iidx+=width) {
-        val = tmp_val[iidx];
-        if (val < bestval) {
-          bestidx = tmp_idx[iidx];
-          bestval = val;
+      int i = 0;
+
+      for (;(i+3)<minpar;i+=4,iidx+=4*width) {
+        float4 vv = (float4)(tmp_val[iidx+0*width], tmp_val[iidx+1*width], tmp_val[iidx+2*width], tmp_val[iidx+3*width]);
+        if (any(vv < bestval)) {
+          // Someone is negative, figure out who
+          if (vv.s0 < bestval) {
+            bestidx = tmp_idx[iidx];
+            bestval = vv.s0;
+          }
+          if (vv.s1 < bestval) {
+            bestidx = tmp_idx[iidx+width];
+            bestval = vv.s1;
+          }
+          if (vv.s2 < bestval) {
+            bestidx = tmp_idx[iidx+2*width];
+            bestval = vv.s2;
+          }
+          if (vv.s3 < bestval) {
+            bestidx = tmp_idx[iidx+3*width];
+            bestval = vv.s3;
+          }
         }
       }
+
       indexes[ch] = bestidx;
     }
     """).build()

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -169,7 +169,12 @@ class PatternOpenCL(Pattern):
         self.result_match = cl.Buffer(openclctx, mf.HOST_NO_ACCESS, 4*40*self.n)
 
         # How much to split the min search by vertically
-        self.minpar = 256
+        # DANGER: Heuristic, probably varies by hardware, possibly want to
+        # vary on len(inp) as well and opencl hardware config
+        if self.n > 32768:
+            self.minpar = 1024
+        else:
+            self.minpar = 512
 
         # Temporaries used during parallel min (value and index)
         self.mintmp_val = cl.Buffer(openclctx, mf.HOST_NO_ACCESS, 4*40*self.minpar)

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -67,13 +67,28 @@ class PatternOpenCL(Pattern):
       int inindex = patstart + npatterns*ch;
       int bestidx = patstart;
       float bestval = input[inindex];
-      float val;
+      float4 vv;
 
-      for (int p=patstart; p<patend; p++, inindex+=1) {
-        val = input[inindex];
-        if (val < bestval) {
-          bestval = val;
-          bestidx = p;
+      for (int p=patstart; (p+3) < patend; p+=4, inindex+=4) {
+        vv = vload4(0, input+inindex);
+        if (any(vv < bestval)) {
+          // Someone is negative, figure out who
+          if (vv.s0 < bestval) {
+            bestidx = p;
+            bestval = vv.s0;
+          }
+          if (vv.s1 < bestval) {
+            bestidx = p+1;
+            bestval = vv.s1;
+          }
+          if (vv.s2 < bestval) {
+            bestidx = p+2;
+            bestval = vv.s2;
+          }
+          if (vv.s3 < bestval) {
+            bestidx = p+3;
+            bestval = vv.s3;
+          }
         }
       }
 

--- a/teletext/vbi/patternopencl.py
+++ b/teletext/vbi/patternopencl.py
@@ -26,11 +26,12 @@ class PatternOpenCL(Pattern):
       int iidx = x * 8;
       int ridx = (x * get_global_size(1)) + y;
       int pidx = y * 24;
+      float d;
 
       result[ridx] = 0;
 
       for (int i=range_low;i<range_high;i++) {
-        float d = input[iidx+i] - patterns[pidx+i];
+        d = input[iidx+i] - patterns[pidx+i];
         result[ridx] += (d*d);
       }
     }
@@ -55,9 +56,10 @@ class PatternOpenCL(Pattern):
       int inindex = patstart + npatterns*ch;
       int bestidx = patstart;
       float bestval = input[inindex];
+      float val;
 
       for (int p=patstart; p<patend; p++, inindex+=1) {
-        float val = input[inindex];
+        val = input[inindex];
         if (val < bestval) {
           bestval = val;
           bestidx = p;
@@ -82,10 +84,11 @@ class PatternOpenCL(Pattern):
       int iidx = ch;
       int bestidx = tmp_idx[iidx];
       float bestval = tmp_val[iidx];
+      float val;
 
       iidx+=width;
       for (int i=1;i<minpar;i++,iidx+=width) {
-        float val = tmp_val[iidx];
+        val = tmp_val[iidx];
         if (val < bestval) {
           bestidx = tmp_idx[iidx];
           bestval = val;


### PR DESCRIPTION
This is built on top of the other pull requests.
There's two main performance improvements here, which get me from about 200lps to about 1000lps in the streams with a lot of 8 bit data.

First I change the split between the two min stages from 256 to 1024 for the
big pattern cases; that gets a factor of 2 on the big cases.  I only do it in the big cases because it makes the 8k case work.  This is heuristic and may need tuning for other hardware based on OpenCL config data.

Secondly I vectorise all the kernels (and more than my first attempt); this is getting the promised 4x improvement vectorising should get when I look at the time taken to run a 65k line.

I also include the flags to turn on OpenCL profiling which is what let me figure some of this out.
