### PR TITLE
HTML: Fix rows not being rendered properly

### DIFF
--- a/misc/teletext-noscanlines.css
+++ b/misc/teletext-noscanlines.css
@@ -19,6 +19,9 @@ a:hover {color: orange; } a:active {color: red;}
     filter:blur(0.5px) brightness(120%);
 }
 
+.row{
+    display: flex;
+}
 
 .subpage:after{
     content: "";


### PR DESCRIPTION
The "row" attribute is currently missing styling, which causes all elements to be displayed on one line. As per issue #81 this returns back the original implementation of this attribute, thus restoring the functionality.

Before:
![image](https://github.com/user-attachments/assets/b28f709c-75b1-417d-991d-64f8ff8308d3)

After:
![image](https://github.com/user-attachments/assets/89fd95af-e411-4377-8989-885a660af69e)
