### PR TITLE
Add support for cx23885 cards and update saa7131 config

### DIFF
--- a/teletext/vbi/config.py
+++ b/teletext/vbi/config.py
@@ -92,11 +92,19 @@ class Config(object):
         },
         'saa7131': {
             'sample_rate': 27000000.0,
-            'line_length': 1440,
-            'line_start_range': (0, 20),
+            'line_length': 2048,
+            'line_start_range': (0, 60),
             'dtype': np.uint8,
-            'field_lines': 16,
+            'field_lines': 17,
             'field_range': range(0, 16),
+        },
+        'cx23885': {
+            'sample_rate': 27000000.0,
+            'line_length': 1440,
+            'line_start_range': (0, 60),
+            'dtype': np.uint8,
+            'field_lines': 18,
+            'field_range': range(1, 17),
         },
     }
 


### PR DESCRIPTION
With Raspberry Pi as a teletext source (the sample teletext), `vbiview` gave me garbled lines when trying to capture with saa7131-based card. However. the results were better when the following parameters were taken into account from saa7134-vbi.c :

[#define VBI_LINE_COUNT     17](https://github.com/torvalds/linux/blob/08733088b566b58283f0f12fb73f5db6a9a9de30/drivers/media/pci/saa7134/saa7134-vbi.c#L35)
[#define VBI_LINE_LENGTH  2048](https://github.com/torvalds/linux/blob/08733088b566b58283f0f12fb73f5db6a9a9de30/drivers/media/pci/saa7134/saa7134-vbi.c#L36)

This procedure can be applied to add support for cx23885/7/8-based PCI-E cards. 

[#define VBI_LINE_LENGTH 1440](https://github.com/torvalds/linux/blob/4e82c87058f45e79eeaa4d5bcc3b38dd3dce7209/drivers/media/pci/cx23885/cx23885-vbi.c#L31C1-L31C29)
[#define VBI_PAL_LINE_COUNT 18](https://github.com/torvalds/linux/blob/4e82c87058f45e79eeaa4d5bcc3b38dd3dce7209/drivers/media/pci/cx23885/cx23885-vbi.c#L33)
[f->fmt.vbi.sampling_rate = 27000000;](https://github.com/torvalds/linux/blob/4e82c87058f45e79eeaa4d5bcc3b38dd3dce7209/drivers/media/pci/cx23885/cx23885-vbi.c#L41)

Roughly the same space for jitter is left (as in cx88 config). Can probably be a little less (like 50 or 40). Captured files are attached. 
[raspi-saa7131.zip](https://github.com/user-attachments/files/19551405/raspi-saa7131.zip)
[raspi-cx23885.zip](https://github.com/user-attachments/files/19551452/raspi-cx23885.zip)


After applying the updated `config.py` file the procedure was:
**- For saa7131:**
Capture using:
`teletext record -c saa7131 -d /dev/vbi0 > raspi-saa7131.vbi`

**The `.vbi` file can be viewed by:**
`teletext vbiview -c saa7131 raspi-saa7131.vbi`
![1](https://github.com/user-attachments/assets/1a522ac7-e2b6-49fb-ad5c-e347bc84652f)
![2](https://github.com/user-attachments/assets/04e2566e-5725-4426-985a-273e7941cb55)

The `.vbi` file can be deconvolved to a `.t42` file by:
`teletext deconvolve -c saa7131 raspi-saa7131.vbi > raspi-saa7131.t42`
The latter can be viewed in any program that supports `.t42` files.

**- For cx23885:**
Capture using:
`teletext record -c cx23885 -d /dev/vbi1 > raspi-cx23885.vbi`

**The `.vbi` file can be viewed by:**
`teletext vbiview -c cx23885 raspi-cx23885.vbi`
![3](https://github.com/user-attachments/assets/2f20c4a1-8a34-4349-bc01-fedcee9de711)
![4](https://github.com/user-attachments/assets/a1091a4c-8212-41b1-935b-fdf11379b35f)

The `.vbi` file can be deconvolved to a `.t42` file by:
`teletext deconvolve -c cx23885 raspi-cx23885.vbi > raspi-cx23885.t42`
The latter can be viewed in any program that supports `.t42` files.